### PR TITLE
SNOW-15: Fixed WP error from adding panel widgets

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -144,8 +144,11 @@ $snow_panels = array(
 
 /* Register and initialise all panels in $snow_panels */
 foreach ($snow_panels as $panel) {
-    register_widget( new snow_panel_widget($panel['id'], $panel['title'], $panel['category']) );
-    add_action('widgets_init', $panel['id']);
+    $new_widget = new snow_panel_widget($panel['id'], $panel['title'], $panel['category']);
+    $register_panel = function() use ($new_widget) {
+        register_widget( $new_widget );
+    };
+    add_action('widgets_init', $register_panel);
 }
 
 /* Enable shortcodes */


### PR DESCRIPTION
JIRA: [SNOW-15](https://issues.fluidproject.org/browse/SNOW-15)

In the foreach loop we used an anonymous function and assigned it to variable $register_panel and put that in add_action so that it would satisfy the condition of using a function.